### PR TITLE
Fix React Server Components CVE vulnerabilities

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@fontsource/firago": "^5.2.5",
         "framer-motion": "^12.16.0",
         "i18next": "^25.3.2",
-        "next": "15.2.5",
+        "next": "15.2.8",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-i18next": "^15.6.0",
@@ -2142,9 +2142,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.2.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.5.tgz",
-      "integrity": "sha512-uWkCf9C8wKTyQjqrNk+BA7eL3LOQdhL+xlmJUf2O85RM4lbzwBwot3Sqv2QGe/RGnc3zysIf1oJdtq9S00pkmQ==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.8.tgz",
+      "integrity": "sha512-TaEsAki14R7BlgywA05t2PFYfwZiNlGUHyIQHVyloXX3y+Dm0HUITe5YwTkjtuOQuDhuuLotNEad4VtnmE11Uw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -8745,12 +8745,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.2.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.2.5.tgz",
-      "integrity": "sha512-LlqS8ljc7RWR3riUwxB5+14v7ULAa5EuLUyarD/sFgXPd6Hmmscg8DXcu9hDdh5atybrIDVBrFhjDpRIQo/4pQ==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.2.8.tgz",
+      "integrity": "sha512-pe2trLKZTdaCuvNER0S9Wp+SP2APf7SfFmyUP9/w1SFA2UqmW0u+IsxCKkiky3n6um7mryaQIlgiDnKrf1ZwIw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.2.5",
+        "@next/env": "15.2.8",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "@fontsource/firago": "^5.2.5",
     "framer-motion": "^12.16.0",
     "i18next": "^25.3.2",
-    "next": "15.2.5",
+    "next": "15.2.8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-i18next": "^15.6.0",


### PR DESCRIPTION
Updated dependencies to fix Next.js and React CVE vulnerabilities.

The fix-react2shell-next tool automatically updated the following packages to their secure versions:
- next
- react-server-dom-webpack
- react-server-dom-parcel  
- react-server-dom-turbopack

All package.json files have been scanned and vulnerable versions have been patched to the correct fixed versions based on the official React advisory.